### PR TITLE
Update slug to match WPORG

### DIFF
--- a/wftda-rankings-widget.php
+++ b/wftda-rankings-widget.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * @link              https://bit.ly/Stray_Taco
- * @since             0.1.0
- * @package           League_Wftda_Ranking
+ * @link    https://bit.ly/Stray_Taco
+ * @since   0.1.0
+ * @package League_Wftda_Ranking
  *
  * @wordpress-plugin
  * Plugin Name:       WFTDA Rankings Widget
- * Plugin URI:        https://github.com/GeoJunkie/league-wftda-ranking
+ * Plugin URI:        https://wordpress.org/plugins/wftda-rankings-widget/
  * Description:       A widget to show a WFTDA league's ranking information in a widget.
  * Version:           1.0.2
  * Author:            Mike Straw (aka Stray Taco)
@@ -19,42 +19,44 @@
  */
 
 // If this file is called directly, abort.
-if ( ! defined( 'WPINC' ) ) {
-	die;
+if (! defined('WPINC') ) {
+    die;
 }
 
 /**
  * Current plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define( 'LEAGUE_WFTDA_RANKING_VERSION', '1.0.2' );
+define('LEAGUE_WFTDA_RANKING_VERSION', '1.0.2');
 
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-league-wftda-ranking-activator.php
  */
-function activate_league_wftda_ranking() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-league-wftda-ranking-activator.php';
-	League_Wftda_Ranking_Activator::activate();
+function activate_league_wftda_ranking()
+{
+    include_once plugin_dir_path(__FILE__) . 'includes/class-league-wftda-ranking-activator.php';
+    League_Wftda_Ranking_Activator::activate();
 }
 
 /**
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-league-wftda-ranking-deactivator.php
  */
-function deactivate_league_wftda_ranking() {
-	require_once plugin_dir_path( __FILE__ ) . 'includes/class-league-wftda-ranking-deactivator.php';
-	League_Wftda_Ranking_Deactivator::deactivate();
+function deactivate_league_wftda_ranking()
+{
+    include_once plugin_dir_path(__FILE__) . 'includes/class-league-wftda-ranking-deactivator.php';
+    League_Wftda_Ranking_Deactivator::deactivate();
 }
 
-register_activation_hook( __FILE__, 'activate_league_wftda_ranking' );
-register_deactivation_hook( __FILE__, 'deactivate_league_wftda_ranking' );
+register_activation_hook(__FILE__, 'activate_league_wftda_ranking');
+register_deactivation_hook(__FILE__, 'deactivate_league_wftda_ranking');
 
 /**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */
-require plugin_dir_path( __FILE__ ) . 'includes/class-league-wftda-ranking.php';
+require plugin_dir_path(__FILE__) . 'includes/class-league-wftda-ranking.php';
 
 /**
  * Begins execution of the plugin.
@@ -63,12 +65,13 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-league-wftda-ranking.php';
  * then kicking off the plugin from this point in the file does
  * not affect the page life cycle.
  *
- * @since    1.0.0
+ * @since 1.0.0
  */
-function run_league_wftda_ranking() {
+function run_league_wftda_ranking()
+{
 
-	$plugin = new League_Wftda_Ranking();
-	$plugin->run();
+    $plugin = new League_Wftda_Ranking();
+    $plugin->run();
 
 }
 run_league_wftda_ranking();


### PR DESCRIPTION
When the plugin was originally published, I thought the submitted slug wouldn't meet the [WordPress.org criteria for slug naming](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#17-plugins-must-respect-trademarks-copyrights-and-project-names), so I updated my submission to use `league-wftda-ranking`.  However, it was approved under the original slug. This caused conflicts, so I'm updating the pertinent info/files here.